### PR TITLE
Make exports paths relative for compatibility purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "typings": "dist/index.d.ts",
     "exports": {
         ".": {
-            "browser": "dist/index.module.js",
-            "umd": "dist/index.umd.js",
-            "import": "dist/index.module.js",
-            "require": "dist/index.js"
+            "browser": "./dist/index.module.js",
+            "umd": "./dist/index.umd.js",
+            "import": "./dist/index.module.js",
+            "require": "./dist/index.js"
         }
     },
     "files": [


### PR DESCRIPTION
Fixes this error on some versions of node/npm:

`Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "dist/index.js" defined in the package config node_modules/react-interval-hook/package.json; targets must start with "./"
`